### PR TITLE
check for empty arrays and return zero confidence

### DIFF
--- a/lib/u_mann_whitney.rb
+++ b/lib/u_mann_whitney.rb
@@ -114,7 +114,7 @@ class UMannWhitney
     ds[:ranked] = ds[:data].ranked
     @n = ds.nrows
 
-    @r1 = ds.filter_rows { |r| r[:g] == 0}[:ranked].sum
+    @r1 = ds.filter_rows { |r| r[:g] == 0}[:ranked].sum || 0
     @r2 = ((ds.nrows * (ds.nrows + 1)).quo(2)) - r1
     @u1 = r1 - ((@n1 * (@n1 + 1)).quo(2))
     @u2 = r2 - ((@n2 * (@n2 + 1)).quo(2))

--- a/spec/u_mann_whitney_spec.rb
+++ b/spec/u_mann_whitney_spec.rb
@@ -6,29 +6,43 @@ RSpec.describe UMannWhitney do
   end
 
   describe UMannWhitney do
-    before do
-      @v1 = Daru::Vector.new([1, 2, 3, 4, 7, 8, 9, 10, 14, 15])
-      @v2 = Daru::Vector.new([5, 6, 11, 12, 13, 16, 17, 18, 19])
-      @u = UMannWhitney.new(@v1, @v2)
+    describe "with valid values" do
+      before do
+        @v1 = Daru::Vector.new([1, 2, 3, 4, 7, 8, 9, 10, 14, 15])
+        @v2 = Daru::Vector.new([5, 6, 11, 12, 13, 16, 17, 18, 19])
+        @u = UMannWhitney.new(@v1, @v2)
+      end
+
+      it 'has same result using class or Test#u_mannwhitney' do
+        expect(UMannWhitney.u_mannwhitney(@v1, @v2).u).to eq @u.u
+      end
+
+      it 'has correct U values' do
+        expect(@u.r1).to eq 73
+        expect(@u.r2).to eq 117
+        expect(@u.u).to eq 18
+      end
+
+      it 'has correct value for z' do
+        expect(@u.z).to be_within(0.001).of(-2.205)
+      end
+
+      it 'has correct value for z and exact probability' do
+        expect(@u.probability_z).to be_within(0.001).of(0.027)
+        expect(@u.probability_exact).to be_within(0.001).of(0.028)
+      end
     end
 
-    it 'has same result using class or Test#u_mannwhitney' do
-      expect(UMannWhitney.u_mannwhitney(@v1, @v2).u).to eq @u.u
-    end
+    describe "with invalid values" do
+      before do
+        @v1 = Daru::Vector.new([])
+        @v2 = Daru::Vector.new([])
+        @u = UMannWhitney.new(@v1, @v2)
+      end
 
-    it 'has correct U values' do
-      expect(@u.r1).to eq 73
-      expect(@u.r2).to eq 117
-      expect(@u.u).to eq 18
-    end
-
-    it 'has correct value for z' do
-      expect(@u.z).to be_within(0.001).of(-2.205)
-    end
-
-    it 'has correct value for z and exact probability' do
-      expect(@u.probability_z).to be_within(0.001).of(0.027)
-      expect(@u.probability_exact).to be_within(0.001).of(0.028)
+      it 'returns zero confidence' do
+        expect(@u.u).to eq 0
+      end
     end
   end
 end


### PR DESCRIPTION
Ensures that passing `[]` to the initializer doesn't blow up, and instead returns zero confidence.