### PR TITLE
silence daru's warnings about optional dependencies at runtime

### DIFF
--- a/lib/u_mann_whitney.rb
+++ b/lib/u_mann_whitney.rb
@@ -1,6 +1,6 @@
 require 'u_mann_whitney/version'
 require 'distribution'
-require 'daru'
+require 'u_mann_whitney/silent_daru'
 
 #
 # = U Mann-Whitney test

--- a/lib/u_mann_whitney/silent_daru.rb
+++ b/lib/u_mann_whitney/silent_daru.rb
@@ -1,0 +1,9 @@
+# Daru makes a lot of noise about optional dependencies. We don't want
+# them, never will.
+begin
+  original_stderr = $stderr
+  $stderr = File.open(File::NULL, "w")
+  require 'daru'
+ensure
+  $stderr = original_stderr
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require "bundler/setup"
 require "u_mann_whitney"
-require "daru"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
It's just noise that we don't want to see every time we load the gem.